### PR TITLE
fix #8, add PyCall as dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,22 +9,23 @@ NamedTupleTools = "d9ec5142-1e00-5aa0-9d6a-321866360f50"
 POMDPModelTools = "08074719-1b2a-587c-a292-00f91cc44415"
 POMDPTesting = "92e6a534-49c2-5324-9027-86e3c861ab81"
 POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
+PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-POMDPs = "0.8.1"
-POMDPModelTools = "0.2.0"
 BeliefUpdaters = "0.1.2"
 NamedTupleTools = "0.11.0"
+POMDPModelTools = "0.2.0"
 POMDPTesting = "0.2.0"
+POMDPs = "0.8.1"
 julia = "1"
 
 [extras]
+Compose = "a81c6b42-2e10-5240-aca2-a61377ecd94b"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 POMDPPolicies = "182e52fb-cfd0-5e46-8c26-fd0667c990f4"
 POMDPSimulators = "e0d0a172-29c6-5d4e-96d0-f262df5d01fd"
-Compose = "a81c6b42-2e10-5240-aca2-a61377ecd94b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/examples/issue_8.py
+++ b/examples/issue_8.py
@@ -1,0 +1,172 @@
+import julia
+from julia.QuickPOMDPs import DiscreteExplicitPOMDP, QuickPOMDP
+from julia.POMDPs import solve, pdf, states
+from julia.QMDP import QMDPSolver
+from julia.SARSOP import SARSOPSolver
+from julia.POMDPPolicies import alphavectors, RandomPolicy
+from julia.POMDPModelTools import Deterministic, SparseCat
+from julia.POMDPSimulators import stepthrough, HistoryRecorder, eachstep, simulate
+from julia import Base
+from julia import Random
+
+import pickle
+import itertools
+import copy
+import time
+import itertools
+from collections import namedtuple
+import typing
+import random
+
+class POMDPGenerator:
+    def __init__(self, seed=1234):
+        self.states = ['left', 'right']
+        self.actions = ['left', 'right', 'listen']
+        self.observations = ['left', 'right']
+        
+        self.rng = random.Random(seed)
+        self.good_obs = .85
+        self.init_state = .5
+        self.random_obs = .5
+  
+    def initialstate_distribution(self):
+        return SparseCat(self.states, [self.init_state, 1-self.init_state])
+    
+    def transition(self, s, a):
+        if a == 'listen':
+            sp = s
+            return SparseCat([sp], [1.0])
+        else: # a door is opened
+            return self.initialstate_distribution()
+        
+    def transition2(self, s, a, sp):
+        if a == 'listen':
+            if sp == s:
+                return 1.0
+            else:
+                return 0.0
+        else: # a door is opened
+            #d= self.initialstate_distribution()
+            if sp=='left':
+                return self.init_state
+            else:
+                return 1.0-self.init_state
+        
+    def observation(self, arg1, arg2, arg3=None):        
+        if arg3 == None:
+            return self.observation2(arg1, arg2)
+        else:
+            return self.observation2(arg2, arg3)
+        
+    def observation2(self, a, sp):
+        if a == 'listen':
+            if 'left' == sp:
+                return SparseCat(['left', 'right'], [self.good_obs, 1.0-self.good_obs])
+            else:
+                return SparseCat(['left', 'right'], [1.0-self.good_obs, self.good_obs])
+        else:
+            return SparseCat(['left', 'right'], [self.random_obs, 1.0-self.random_obs])
+        
+    def observation3(self, a, sp, o):
+        if a == 'listen':
+            if o == sp:
+                return self.good_obs
+            else:
+                return 1.0-self.good_obs
+        else:
+            if o == 'left':
+                return self.random_obs
+            else:
+                return 1.0-self.random_obs
+
+            
+    def reward(self, s, a, sp=None, o=None):
+        if a == 'listen':
+            return -1.0
+        elif s == a: # the tiger was found
+            return -100.0
+        else: # the tiger was escaped
+            return 10.0
+        
+    def generate_pomdp(self, discount=0.95):
+        
+        return QuickPOMDP(
+            initialstate_distribution = self.initialstate_distribution,
+            transition = self.transition,
+            observation = self.observation,
+            reward=self.reward,
+            states=self.states,
+            actions=self.actions,
+            observations=self.observations,
+            discount=discount,
+        )
+    
+    def generate_pomdp2(self, discount=0.95):
+        
+        return DiscreteExplicitPOMDP(
+            self.states,
+            self.actions,
+            self.observations,
+            self.transition2,
+            self.observation3,
+            self.reward,
+            discount,
+            self.initialstate_distribution(),
+        )
+    
+    def isterminal(self, s):
+        return s =='terminal'
+    
+    def generate_pomdp_with_terminal(self, discount=0.95):
+        
+        return QuickPOMDP(
+            initialstate_distribution = self.initialstate_distribution,
+            transition = self.transition,
+            observation = self.observation,
+            reward=self.reward,
+            states=self.states + ['terminal'],
+            actions=self.actions,
+            observations=self.observations,
+            discount=discount,
+            isterminal=self.isterminal
+        )
+    
+    def generate_pomdp_without_terminal(self, discount=0.95):
+        
+        return QuickPOMDP(
+            initialstate_distribution = self.initialstate_distribution,
+            transition = self.transition,
+            observation = self.observation,
+            reward=self.reward,
+            states=self.states + ['terminal'],
+            actions=self.actions,
+            observations=self.observations,
+            discount=discount,
+        )
+
+Gen = POMDPGenerator()
+pomdp = Gen.generate_pomdp()
+
+solver = SARSOPSolver()
+policy = solve(solver, pomdp)
+
+print('alpha vectors:')
+for v in alphavectors(policy):
+    print(v)
+
+print()
+
+for step in stepthrough(pomdp, policy, "s,a,o", max_steps=10):
+    print(step.s)
+    print(step.a)
+    print(step.o)
+    print()
+
+Gen = POMDPGenerator()
+pomdp = Gen.generate_pomdp_with_terminal()
+policy = RandomPolicy(pomdp)
+for step in stepthrough(pomdp, policy, "s,a,o", max_steps=10):
+    print(step.s)
+    print(step.a)
+    print(step.o)
+    print()

--- a/src/QuickPOMDPs.jl
+++ b/src/QuickPOMDPs.jl
@@ -7,6 +7,7 @@ using POMDPTesting
 using UUIDs
 using NamedTupleTools
 using Random
+using PyCall
 
 export
     DiscreteExplicitPOMDP,

--- a/src/quick.jl
+++ b/src/quick.jl
@@ -73,9 +73,7 @@ const QuickModel = Union{QuickMDP, QuickPOMDP}
 function convert_pyobjects!(kwd::Dict)
     for (k, v) in kwd
         if v isa PyObject && pybuiltin("callable")(v)
-            jv = convert(Function, v)
-            kwd[k] = jv
-            println("converting $v to $jv")
+            kwd[k] = convert(Function, v)
         end
     end
 end

--- a/src/quick.jl
+++ b/src/quick.jl
@@ -72,8 +72,8 @@ const QuickModel = Union{QuickMDP, QuickPOMDP}
 
 function convert_pyobjects!(kwd::Dict)
     for (k, v) in kwd
-        if v isa PyObject
-            jv = convert(PyAny, v)
+        if v isa PyObject && pybuiltin("callable")(v)
+            jv = convert(Function, v)
             kwd[k] = jv
             println("converting $v to $jv")
         end
@@ -122,11 +122,6 @@ function quick_defaults!(kwd::Dict)
                 kwd[:obsindex] = Dict(s=>i for (i,s) in enumerate(observations))
             end
         end
-    end
-
-    states = _call(Val(:states), kwd[:states], ())
-    for s in states
-        @show s
     end
 end
 


### PR DESCRIPTION
The fix to be able to use the quick interface from python requires a dependency on PyCall. That seems like a pretty heavy dependency. Options are:

1. Depend on PyCall
2. Create a new package - something like PyQuickPOMDPs
3. Ask python users to call `convert(Function, mymethod)` whenever they supply a function keyword argument to a Quick(PO)MDP constructor

Any votes?