### PR TITLE
Don't use deprecated POMDPModelTools in example

### DIFF
--- a/docs/src/quick.md
+++ b/docs/src/quick.md
@@ -9,7 +9,7 @@ The quick interface is perhaps best demonstrated by an example. The code below d
 
 ```jldoctest; output = false, filter = r".*"
 using QuickPOMDPs
-using POMDPModelTools: Deterministic
+using POMDPTools: Deterministic
 
 mountaincar = QuickMDP(
     function (s, a, rng)        


### PR DESCRIPTION
I was copying example and it was not compatible with anything cos it only allowed ancient versions of StatsBase etc